### PR TITLE
move email `from` field to env variables

### DIFF
--- a/src/emails/sender.ts
+++ b/src/emails/sender.ts
@@ -89,7 +89,7 @@ async function prepareEmail<T extends TemplateData>({
 }: PrepareEmailProps<T>): Promise<PreparedEmail> {
   const emailRenderProps = { ...templateProps, APP_URL: env.APP_URL }
 
-  const from = 'Interval <help@interval.com>'
+  const from = env.EMAIL_FROM
   const subject = subjectBuilder(templateProps)
   const html = await emailTemplate.render(template, emailRenderProps)
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -21,6 +21,7 @@ const schema = z.object({
 
   // emails
   POSTMARK_API_KEY: z.string().optional(),
+  EMAIL_FROM: z.string().optional().default('Interval <help@interval.com>'),
 
   // authentication
   WORKOS_API_KEY: z.string().optional(),


### PR DESCRIPTION
As reported by others in #2, being able to customize the `from` field is a requirement to send e-mails using Postmark with on premise deployments.

