### PR TITLE
feat: improve general deploy experience

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+node_modules
+dist
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ WORKDIR /app
 
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/prisma ./prisma
 
 CMD [ "node", "dist/src/entry.js", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,7 @@ WORKDIR /app
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/email-templates ./email-templates
+COPY --from=builder /app/public ./public
 
 CMD [ "node", "dist/src/entry.js", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,20 @@
-FROM node:18-alpine
-RUN npm i --save-prod -g @interval/server
-EXPOSE 3000
-CMD [ "interval-server", "start"]
+FROM node:18.18.0-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+
+RUN yarn install --frozen-lockfile
+
+COPY . .
+
+RUN yarn build
+
+FROM node:18.18.0-alpine AS runner
+
+WORKDIR /app
+
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+
+CMD [ "node", "dist/src/entry.js", "start" ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Interval Server
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/tFqAVW?referralCode=chIZYq)
 
 Interval Server is the central node used to run applications developed with the [Interval SDK](https://github.com/interval/interval-node).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Interval Server
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/tFqAVW?referralCode=chIZYq)
 
 Interval Server is the central node used to run applications developed with the [Interval SDK](https://github.com/interval/interval-node).
 
@@ -24,11 +23,12 @@ Interval Server is a pure Node.js application. Node.js version 16 or higher is r
 - [Postmark](https://postmarkapp.com) is used for sending application emails. In the future we may introduce a vendor-agnostic path for sending emails. If a `POSTMARK_API_KEY` environment variable is not provided when running Interval server, emails will not be sent.
 - [WorkOS](https://workos.com) is used for SSO, directory sync, and Sign in with Google. If `WORKOS_API_KEY`,`WORKOS_CLIENT_ID`, and `WORKOS_WEBHOOK_SECRET` environment variables are not provided when running Interval Server, these functions will not be available.
 - [Slack](https://slack.com) can be used to send notifications via Interval's [notify](https://interval.com/docs/action-context/notify) methods. If `SLACK_CLIENT_ID` and `SLACK_CLIENT_SECRET` environment variables are not provided when running Interval Server, notifications cannot be sent via Slack.
-- [S3](https://aws.amazon.com/s3/) can be used to support file uploads via Interval's [file input](https://interval.com/docs/io-methods/input-file) methods. If `S3_KEY_ID`,`S3_KEY_SECRET`,`S3_BUCKET`, and `S3_REGION` environment variables are not provided when running Interval Server, file uploads will not function properly.
+- [S3](https://aws.amazon.com/s3/) or S3-compatible storage providers (like [MinIO](https://min.io/) or [Cloudflare R2](https://www.cloudflare.com/products/r2/)) can be used to support file uploads via Interval's [file input](https://interval.com/docs/io-methods/input-file) methods. If `S3_KEY_ID`,`S3_KEY_SECRET`,`S3_BUCKET`,`S3_REGION`, and `S3_ENDPOINT` environment variables are not provided when running Interval Server, file uploads will not function properly. For S3-compatible providers, make sure to set the appropriate endpoint URL in `S3_ENDPOINT`.
 
-### S3 bucket configuration 
+### S3 bucket configuration
 
-To support file uploads, you will need to configure your S3 bucket for [Cross-origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html).   Here's an example policy:
+To support file uploads, you will need to configure your S3 bucket for [Cross-origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html). Here's an example policy:
+
 ```
 [
     {
@@ -51,7 +51,7 @@ To support file uploads, you will need to configure your S3 bucket for [Cross-or
         "MaxAgeSeconds": 3000
     }
 ]
-``` 
+```
 
 ## Required environment variables
 
@@ -63,7 +63,7 @@ To support file uploads, you will need to configure your S3 bucket for [Cross-or
 
 ### Ports
 
-Interval Server runs services on ports `3000` and `3033`. The main service runs on `3000`.
+Interval Server runs services on port `3000`.
 
 ## Running Interval Server locally
 
@@ -82,9 +82,8 @@ WSS_API_SECRET=<YOUR WSS API SECRET>
 
 _Note:_ you don't _need_ to use a `.env` file. As long as the [required variables](#required-environment-variables) are set, you should be good to go.
 
-3. If you _have not_ already setup a database, run `interval-server db-init` to initialize one.
-4. Run `interval-server start` to run `interval-server`.
-5. 🎉 Visit http://localhost:3000 to access your Interval Server!
+3. Run `interval-server start` to run `interval-server`.
+4. 🎉 Visit http://localhost:3000 to access your Interval Server!
 
 ## Running Interval Server in production
 
@@ -101,7 +100,7 @@ Important things to know:
 
 ## Connecting to Interval Server from your app
 
-Once your Interval Server instance is up and running, it's trivial to connect to it from your Interval apps. Just add an `endpoint` property pointing to your Interval Server instance to the Interval SDK's constructor. For example:
+Once your Interval Server instance is up and running, it's trivial to connect to it from your Interval apps. Just add an `endpoint` property pointing to your Interval Server instance to the Interval SDK's constructor. Interval server also prints the URL on startup in case you need it. For example:
 
 ```js
 const interval = new Interval({
@@ -119,16 +118,6 @@ Once you run `npm i -g @interval/server`, the following commands are available:
 ### `interval-server start`
 
 Starts Interval Server. See above for information on running Interval Server locally or in production.
-
-### `interval-server db-init`
-
-Creates and sets up an Postgres database for use with Interval Server.
-
-[psql](https://www.postgresql.org/docs/7.0/app-psql.htm) must be installed for this command to work.
-
-You must provide a `DATABASE_URL` environment variable of the form `postgresql://username:password@host:port/dbname` when running this command.
-
-By default, the `db-init` command will attempt to create a database with the name provided in your `DATABASE_URL` environment variable. If you've already created the database and just need to apply create the appropriate tables etc., you can run `interval-server db-init --skip-create` to skip the database creation step.
 
 ## Contributing
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -126,7 +126,7 @@ async function main() {
     await setupDb()
 
     // start the internal web socket server
-    // import('./wss/index')
+    import('./wss/index')
 
     const app = express()
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -126,7 +126,7 @@ async function main() {
     await setupDb()
 
     // start the internal web socket server
-    import('./wss/index')
+    // import('./wss/index')
 
     const app = express()
 
@@ -142,7 +142,7 @@ async function main() {
 
     server.listen(Number(envVars.PORT), () => {
       logger.info(
-        `📡 Interval Server listening at http://localhost:${envVars.PORT}`
+        `📡 Interval Server listening at ${envVars.APP_URL}`
       )
     })
   }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -145,7 +145,7 @@ async function main() {
         `📡 Interval Server listening at ${envVars.APP_URL}`
       )
       logger.info(
-        `💡 Access the Interval Server through the SDK with wss://${new URL(envVars.APP_URL).origin}/websocket`
+        `💡 Access the Interval Server through the SDK with wss://${new URL(envVars.APP_URL).host}/websocket`
       )
     })
   }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -145,7 +145,7 @@ async function main() {
         `📡 Interval Server listening at ${envVars.APP_URL}`
       )
       logger.info(
-        `💡 Access the Interval Server through the SDK with wss://${envVars.APP_URL}/websocket`
+        `💡 Access the Interval Server through the SDK with wss://${new URL(envVars.APP_URL).origin}/websocket`
       )
     })
   }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -144,6 +144,9 @@ async function main() {
       logger.info(
         `📡 Interval Server listening at ${envVars.APP_URL}`
       )
+      logger.info(
+        `💡 Access the Interval Server through the SDK with wss://${envVars.APP_URL}/websocket`
+      )
     })
   }
 }

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -145,7 +145,7 @@ async function main() {
         `📡 Interval Server listening at ${envVars.APP_URL}`
       )
       logger.info(
-        `💡 Access the Interval Server through the SDK with wss://${new URL(envVars.APP_URL).host}/websocket`
+        `💡 Connect SDK using endpoint: wss://${new URL(envVars.APP_URL).host}/websocket`
       )
     })
   }

--- a/src/env.ts
+++ b/src/env.ts
@@ -37,8 +37,7 @@ const schema = z.object({
   S3_KEY_SECRET: z.string().optional(),
   S3_BUCKET: z.string().optional(),
   S3_REGION: z.string().optional(),
-  S3_PRIVATE_ENDPOINT: z.string().optional(),
-  S3_PUBLIC_ENDPOINT: z.string().optional(),
+  S3_ENDPOINT: z.string().optional(),
 })
 
 const possiblyValid = schema.safeParse(process.env)

--- a/src/env.ts
+++ b/src/env.ts
@@ -37,6 +37,7 @@ const schema = z.object({
   S3_KEY_SECRET: z.string().optional(),
   S3_BUCKET: z.string().optional(),
   S3_REGION: z.string().optional(),
+  S3_ENDPOINT: z.string().optional(),
 })
 
 const possiblyValid = schema.safeParse(process.env)

--- a/src/env.ts
+++ b/src/env.ts
@@ -37,7 +37,8 @@ const schema = z.object({
   S3_KEY_SECRET: z.string().optional(),
   S3_BUCKET: z.string().optional(),
   S3_REGION: z.string().optional(),
-  S3_ENDPOINT: z.string().optional(),
+  S3_PRIVATE_ENDPOINT: z.string().optional(),
+  S3_PUBLIC_ENDPOINT: z.string().optional(),
 })
 
 const possiblyValid = schema.safeParse(process.env)

--- a/src/server/healthCheck.ts
+++ b/src/server/healthCheck.ts
@@ -33,9 +33,10 @@ router.get('/', async function (req, res) {
       },
       internalWss: {
         status: wssQuery === null ? 'down' : 'up',
-      }
+      },
     },
     error: {
+      app: null,
       db: userQuery === null ? 'user count query failed' : null,
       internalWss: wssQuery === null ? 'internal wss query failed' : null,
     },

--- a/src/server/healthCheck.ts
+++ b/src/server/healthCheck.ts
@@ -22,17 +22,21 @@ router.get('/', async function (req, res) {
     makeApiCall('/api/health', '').catch(() => null),
   ])
 
-  return res.json({
-    status: 'ok',
+  const dbStatus = userQuery === null ? 'down' : 'up'
+  const internalWssStatus = wssQuery === null ? 'down' : 'up'
+  const appStatus = dbStatus !== 'up' || internalWssStatus !== 'up' ? 'down' : 'up'
+
+  return res.status(appStatus === 'up' ? 200 : 503).json({
+    status: appStatus === 'up' ? 'ok' : 'error',
     info: {
       db: {
-        status: userQuery === null ? 'down' : 'up',
+        status: dbStatus,
       },
       app: {
-        status: 'up',
+        status: appStatus,
       },
       internalWss: {
-        status: wssQuery === null ? 'down' : 'up',
+        status: internalWssStatus,
       },
     },
     error: {

--- a/src/server/trpc/apiKeys.ts
+++ b/src/server/trpc/apiKeys.ts
@@ -10,6 +10,8 @@ import { encryptPassword, generateKey } from '~/server/auth'
 import { hasPermission } from '~/utils/permissions'
 import { getDevKey } from '~/server/utils/apiKey'
 import { DEVELOPMENT_ORG_ENV_SLUG } from '~/utils/environments'
+import env from '~/env'
+import { isEmailEnabled } from '../utils/email'
 
 export const keyRouter = createRouter()
   .middleware(authenticatedMiddleware)
@@ -70,7 +72,7 @@ export const keyRouter = createRouter()
         throw new TRPCError({ code: 'FORBIDDEN' })
       }
 
-      if (usageEnvironment === 'PRODUCTION') {
+      if (isEmailEnabled()) {
         const pendingConfirmation =
           await prisma.userEmailConfirmToken.findFirst({
             where: { userId: user.id, email: null },

--- a/src/server/trpc/user.ts
+++ b/src/server/trpc/user.ts
@@ -10,6 +10,7 @@ import { generatePassword, requestEmailConfirmation } from '~/server/auth'
 import { createUser } from '~/server/user'
 import { hasPermission } from '~/utils/permissions'
 import { logger } from '~/server/utils/logger'
+import { isEmailEnabled } from '../utils/email'
 
 export const userRouter = createRouter()
   .middleware(authenticatedMiddleware)
@@ -94,7 +95,7 @@ export const userRouter = createRouter()
       return user
         ? {
             ...user,
-            isEmailConfirmationRequired: !!pendingConfirmation,
+            isEmailConfirmationRequired: !!pendingConfirmation && isEmailEnabled(),
           }
         : null
     },

--- a/src/server/utils/email.ts
+++ b/src/server/utils/email.ts
@@ -1,0 +1,3 @@
+import env from "env";
+
+export const isEmailEnabled = () => !!env.POSTMARK_API_KEY && !!env.EMAIL_FROM

--- a/src/server/utils/uploads.ts
+++ b/src/server/utils/uploads.ts
@@ -20,7 +20,8 @@ function isS3Available(env: any): env is {
     typeof env.S3_KEY_ID === 'string' &&
     typeof env.S3_KEY_SECRET === 'string' &&
     typeof env.S3_REGION === 'string' &&
-    typeof env.S3_BUCKET === 'string'
+    typeof env.S3_BUCKET === 'string' &&
+    typeof env.S3_ENDPOINT === 'string'
   )
 }
 
@@ -39,6 +40,7 @@ function getS3Client() {
       accessKeyId: env.S3_KEY_ID,
       secretAccessKey: env.S3_KEY_SECRET,
     },
+    endpoint: env.S3_ENDPOINT,
   })
 }
 

--- a/src/server/utils/uploads.ts
+++ b/src/server/utils/uploads.ts
@@ -60,10 +60,11 @@ export async function getIOPresignedUploadUrl(key: string): Promise<string> {
     expiresIn: 3600, // 1 hour
   })
 
-  const url = new URL(signedUrl)
+  let url = new URL(signedUrl)
   if (env.S3_PUBLIC_ENDPOINT) {
-    url.hostname = env.S3_PUBLIC_ENDPOINT.split(':')[0]
-    url.port = env.S3_PUBLIC_ENDPOINT.split(':')[1]
+    const publicEndpoint = new URL(env.S3_PUBLIC_ENDPOINT)
+    publicEndpoint.pathname = url.pathname
+    url = publicEndpoint
   }
 
   return url.toString()

--- a/src/server/utils/uploads.ts
+++ b/src/server/utils/uploads.ts
@@ -15,13 +15,16 @@ function isS3Available(env: any): env is {
   S3_KEY_SECRET: string
   S3_REGION: string
   S3_BUCKET: string
+  S3_PRIVATE_ENDPOINT: string
+  S3_PUBLIC_ENDPOINT: string
 } {
   return (
     typeof env.S3_KEY_ID === 'string' &&
     typeof env.S3_KEY_SECRET === 'string' &&
     typeof env.S3_REGION === 'string' &&
     typeof env.S3_BUCKET === 'string' &&
-    typeof env.S3_ENDPOINT === 'string'
+    typeof env.S3_PRIVATE_ENDPOINT === 'string' &&
+    typeof env.S3_PUBLIC_ENDPOINT === 'string'
   )
 }
 
@@ -40,7 +43,8 @@ function getS3Client() {
       accessKeyId: env.S3_KEY_ID,
       secretAccessKey: env.S3_KEY_SECRET,
     },
-    endpoint: env.S3_ENDPOINT,
+
+    endpoint: env.S3_PRIVATE_ENDPOINT,
   })
 }
 
@@ -56,7 +60,7 @@ export async function getIOPresignedUploadUrl(key: string): Promise<string> {
     expiresIn: 3600, // 1 hour
   })
 
-  return signedUrl
+  return new URL(signedUrl, env.S3_PUBLIC_ENDPOINT).toString()
 }
 
 export async function getIOPresignedDownloadUrl(key: string): Promise<string> {

--- a/src/server/utils/uploads.ts
+++ b/src/server/utils/uploads.ts
@@ -60,7 +60,13 @@ export async function getIOPresignedUploadUrl(key: string): Promise<string> {
     expiresIn: 3600, // 1 hour
   })
 
-  return new URL(signedUrl, env.S3_PUBLIC_ENDPOINT).toString()
+  const url = new URL(signedUrl)
+  if (env.S3_PUBLIC_ENDPOINT) {
+    url.hostname = env.S3_PUBLIC_ENDPOINT.split(':')[0]
+    url.port = env.S3_PUBLIC_ENDPOINT.split(':')[1]
+  }
+
+  return url.toString()
 }
 
 export async function getIOPresignedDownloadUrl(key: string): Promise<string> {

--- a/src/server/utils/uploads.ts
+++ b/src/server/utils/uploads.ts
@@ -43,7 +43,7 @@ function getS3Client() {
       accessKeyId: env.S3_KEY_ID,
       secretAccessKey: env.S3_KEY_SECRET,
     },
-
+    forcePathStyle: true,
     endpoint: env.S3_PRIVATE_ENDPOINT,
   })
 }

--- a/src/server/utils/uploads.ts
+++ b/src/server/utils/uploads.ts
@@ -64,6 +64,7 @@ export async function getIOPresignedUploadUrl(key: string): Promise<string> {
   if (env.S3_PUBLIC_ENDPOINT) {
     const publicEndpoint = new URL(env.S3_PUBLIC_ENDPOINT)
     publicEndpoint.pathname = url.pathname
+    publicEndpoint.search = url.search
     url = publicEndpoint
   }
 

--- a/src/wss/index.ts
+++ b/src/wss/index.ts
@@ -231,4 +231,10 @@ app.post('/api/action-schedules/sync', async (req: Request, res: Response) => {
   }
 })
 
+app.post('/api/health', async (req: Request, res: Response) => {
+  return res.json({
+    status: 'ok',
+  })
+})
+
 app.listen(port)

--- a/src/wss/index.ts
+++ b/src/wss/index.ts
@@ -231,9 +231,4 @@ app.post('/api/action-schedules/sync', async (req: Request, res: Response) => {
   }
 })
 
-app.listen(port, () => {
-  const url = new URL(env.APP_URL)
-  url.port = port.toString()
-
-  logger.info(`📡 Internal WSS API Server listening at ${url.toString()}`)
-})
+app.listen(port)


### PR DESCRIPTION
Hey! Thanks for the great software, helped us a lot in our startup. 
Here's a list of things this PR will make it better to deploy:

- Remove the need for email provider when creating live keys
- Remove the need for psql and thus db-init (it'll run every time the server is started)
- Added support for S3 compatible providers
- Added `/api/health` endpoint that checks all server dependencies (useful for services like Railway or Render)

Also, hoping on adding an automatically build system using Github Actions for the Docker Image and an option to disable user sign ups.

And also, would you guys mind in me adding my Railway template as an option of deploy in the README (one-click deploy of Interval)? I'm asking this because I'll earn some kickback from that template and want to be transparent about it. If not, it's completely fine :)